### PR TITLE
fix: added tqdm dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ scikit-learn==1.5.1
 scipy==1.14.0
 six==1.16.0
 threadpoolctl==3.5.0
+tqdm==4.67.1
 tzdata==2024.1
 neptune==1.13.0


### PR DESCRIPTION
Hey, I ran the DPG in a new env, and noticed there was a dependency missing in the requirements file

Best regards, Matheus.